### PR TITLE
Fix TypeError when file handle is not present in file entry

### DIFF
--- a/anfs/protocol/nfs3/pack.py
+++ b/anfs/protocol/nfs3/pack.py
@@ -1826,7 +1826,7 @@ class NFSFileEntry:
 		realhandle = None
 		try:
 			realhandle = data['name_handle']['handle']['data']
-		except KeyError:
+		except (KeyError, TypeError):
 			pass
 
 		res = NFSFileEntry()


### PR DESCRIPTION
In some cases if a file entry has no file handle, name_handle is None. In this case a TypeError is raised when accessing handle.