### PR TITLE
Add xdrlib3 dependency for python 3.13 support

### DIFF
--- a/anfs/protocol/nfs3/pack.py
+++ b/anfs/protocol/nfs3/pack.py
@@ -1,6 +1,10 @@
 import struct
-from xdrlib import Packer, Unpacker, ConversionError
-from xdrlib import Error as XDRError
+try:
+	from xdrlib import Packer, Unpacker, ConversionError
+	from xdrlib import Error as XDRError
+except:
+	from xdrlib3 import Packer, Unpacker, ConversionError
+	from xdrlib3 import Error as XDRError
 import anfs.protocol.nfs3.messages as const
 from anfs.protocol.nfs3 import rtypes as types
 import datetime

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
 		'colorama',
 		'asn1crypto',
 		'wcwidth',
+		'xdrlib3; python_version>="3.13"',
 	],
 	
 	classifiers=[


### PR DESCRIPTION
In Python 3.13, xdrlib was removed from the standard library.
On newer python versions, an external library is needed to parse xdr.
There are multiple libraries containing the old standard library module. I used this one because it is also used by pynfs: https://github.com/overcat/xdrlib3