### PR TITLE
Improve enumeration, fix export discovery, automatically set uid, add download

### DIFF
--- a/anfs/protocol/mount/messages.py
+++ b/anfs/protocol/mount/messages.py
@@ -39,6 +39,10 @@ class export:
     def __str__(self):
         return 'Filesystem: %s, Groups: %s' % (self.filesys, self.groups)
     
+    def to_smbshare(self, hostname_or_ip):
+        fullpath = '%s%s' % (hostname_or_ip, self.filesys)
+        return NFSSMBShare(name=self.filesys, stype='mount', remark=None, fullpath=fullpath)
+    
 class fhstatus:
     def __init__(self):
         self.status = None

--- a/anfs/protocol/nfs3/pack.py
+++ b/anfs/protocol/nfs3/pack.py
@@ -1894,9 +1894,9 @@ class NFSFileEntry:
 		formatted_line = "{:<10s} {:>2} {:<4} {:<4} {:>5} {:<12}  {}".format(*res)
 		return formatted_line
 	
-	def to_smbfile(self, mountpoint_name, path_to_file):
+	def to_smbfile(self, host_name, mountpoint_name, path_to_file):
 		#returns an SMBfile-like object
-		return NFSSMBFile.from_nfsfileentry(self, mountpoint_name, path_to_file)
+		return NFSSMBFile.from_nfsfileentry(self, host_name, mountpoint_name, path_to_file)
 
 class NFSSMBFile:
 	# this is a class that is used to represent a file in the SMB protocol
@@ -1917,13 +1917,15 @@ class NFSSMBFile:
 		self.attributes = None
 		self.file_id:int = None
 		self.security_descriptor = None
+
+		self.nfs_file = None
 	
 	@staticmethod
-	def from_nfsfileentry(entry, mountpoint_name, path_to_file):
+	def from_nfsfileentry(entry, host_name, mountpoint_name, path_to_file):
 		res = NFSSMBFile()
-		res.fullpath = f"{path_to_file}/{entry.name}"
+		res.fullpath = f"{path_to_file}"
 		res.share_path = mountpoint_name
-		res.unc_path = f"{mountpoint_name}:{path_to_file}/{entry.name}"
+		res.unc_path = f"{host_name}/{mountpoint_name}/{path_to_file}"
 		res.name = entry.name
 		res.size = entry.size
 		res.creation_time = entry.ctime
@@ -1932,6 +1934,7 @@ class NFSSMBFile:
 		res.change_time = entry.mtime
 		res.file_id = entry.fileid
 		res.allocation_size = entry.used
+		res.nfs_file = entry
 		#res.attributes = entry.mode
 		return res
 	

--- a/anfs/protocol/rpc/__init__.py
+++ b/anfs/protocol/rpc/__init__.py
@@ -64,6 +64,7 @@ class RPC:
 				if err is not None:
 					return False, err
 				port, err = await self.__portmap.getport(program, version, protocol)
+				await self.__portmap.disconnect()
 				if err is not None:
 					return False, err
 				self.target = self.target.get_newtarget(self.target.ip, port)
@@ -101,7 +102,7 @@ class RPC:
 			fragment = rpc_fragment_header.to_bytes(4, byteorder='big', signed=False) + fragment
 			await self.connection.write(fragment)
 	
-	async def call(self, program, version, procedure, data):
+	async def call(self, program, version, procedure, data, credential = None):
 		xid, xid_queue = await self.register_xid(self.next_xid())
 		try:
 			call = rpc_msg()
@@ -112,7 +113,7 @@ class RPC:
 			call.body.prog = program
 			call.body.vers = version
 			call.body.proc = procedure
-			call.body.cred = self.credential
+			call.body.cred = self.credential if credential is None else credential
 			call.body.verf = AUTH_NULL() # for both auth null and auth sys, the verifier is null
 			call.body.data = data
 			


### PR DESCRIPTION
Improve export discovery by using the mountd export call instead of dump which provides more accurate results.
Automatically set the right UID and GID when listing a directory during enumeration in order to get access to as many directories as possible.
Add a file download function.